### PR TITLE
Semantic Chapterization Implementation

### DIFF
--- a/backend/agent_a_chat/graph.py
+++ b/backend/agent_a_chat/graph.py
@@ -13,6 +13,7 @@ from .nodes.node_conversation_agent import node_conversation
 from .nodes.node_proactive_engagement import node_proactive_engagement
 from .nodes.node_hydrate import node_hydrate
 from .nodes.node_manage_memory import node_manage_memory
+from .nodes.node_deliver_transcript import node_deliver_transcript
 from .state import ChatState, GraphContext
 
 
@@ -24,20 +25,6 @@ def should_trigger_synth(state: ChatState) -> ChatState:
         return {"synth_status": "requested"}
 
     return {}
-
-
-def node_deliver_transcript(state: ChatState) -> ChatState:
-    return {
-        "messages": [
-            AIMessage(
-                content="Excellent. Let's begin.",
-                additional_kwargs={
-                    "answer": state["answer"], "transcript": state["transcript"]}
-            )
-        ],
-        "awaiting_confirmation": False,
-        "is_synthesis_ready": False  # Reset the flag
-    }
 
 
 def create_chat_graph(checkpointer: BaseCheckpointSaver = None, store: BaseStore = None):

--- a/backend/agent_a_chat/main.py
+++ b/backend/agent_a_chat/main.py
@@ -259,12 +259,14 @@ class ChatResponse(BaseModel):
     user_id: str
     answer: Optional[str] = None
     transcript: Optional[str] = None
+    chapters: Optional[list] = None
 
 
 class SynthesisResult(BaseModel):
     thread_id: str
     answer: str
     transcript: str
+    chapters: Optional[list] = None
     status: str = "completed"
 
 # === Message Saving Helper ===
@@ -465,6 +467,7 @@ async def chat_endpoint(body: ChatRequest, request: Request, bg_tasks: Backgroun
         reply = last_message.content
         answer = last_message.additional_kwargs.get("answer")
         transcript = last_message.additional_kwargs.get("transcript")
+        chapters = last_message.additional_kwargs.get("chapters")
 
         # Save user and AI messages
         await save_message(thread_id, user_id, "user", body.message)
@@ -475,7 +478,8 @@ async def chat_endpoint(body: ChatRequest, request: Request, bg_tasks: Backgroun
             user_id=user_id,
             thread_id=thread_id,
             answer=answer,
-            transcript=transcript
+            transcript=transcript,
+            chapters=chapters
         )
 
     except Exception as e:
@@ -495,6 +499,7 @@ async def handle_synthesis_complete(result: SynthesisResult, request: Request):
     thread_id = result.thread_id
     answer = result.answer
     transcript = result.transcript
+    chapters = result.chapters
     status = result.status
 
     if status != "completed":
@@ -515,6 +520,7 @@ async def handle_synthesis_complete(result: SynthesisResult, request: Request):
             {
                 "answer": answer,
                 "transcript": transcript,
+                "chapters": chapters,
                 "synth_status": "completed",
                 "is_synthesis_ready": True
             }

--- a/backend/agent_a_chat/nodes/node_deliver_transcript.py
+++ b/backend/agent_a_chat/nodes/node_deliver_transcript.py
@@ -1,0 +1,29 @@
+from ..state import ChatState
+from langchain_core.messages import AIMessage
+
+
+async def node_deliver_transcript(state: ChatState) -> ChatState:
+    """
+    Prepares the final transcript with chapterized content for delivery.
+    Adds chapterized transcript to additional_kwargs for the final message.
+    """
+    transcript = state.get("transcript", "")
+    chapters = state.get("chapters", [])
+
+    # Build additional_kwargs with chapterized transcript
+    additional_kwargs = {
+        "answer": state.get("answer", ""),
+        "transcript": transcript,
+        "chapters": chapters
+    }
+
+    return {
+        "messages": [
+            AIMessage(
+                content="Excellent. Let's begin.",
+                additional_kwargs=additional_kwargs
+            )
+        ],
+        "awaiting_confirmation": False,
+        "is_synthesis_ready": False  # Reset the flag
+    }

--- a/backend/agent_a_chat/state.py
+++ b/backend/agent_a_chat/state.py
@@ -19,6 +19,7 @@ class ChatState(TypedDict):
     summary: str
     answer: Optional[str]
     transcript: Optional[str]
+    chapters: Optional[list] = None
     synth_status: Literal["idle", "requested", "in_progress", "completed"]
     is_synthesis_ready: bool
     awaiting_confirmation: bool

--- a/backend/agent_b_synth/agent_executor.py
+++ b/backend/agent_b_synth/agent_executor.py
@@ -31,12 +31,11 @@ class PulseSynthExecutor(AgentExecutor):
 
         self.dependencies = GraphContext(
             llm=llm,
-            logger=logger,
         )
         self.synth_graph = build_synth_graph()
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
-        self.dependencies.logger.info(f"THE REQUEST CONTEXT: {context}")
+        logger.info(f"THE REQUEST CONTEXT: {context}")
 
         query = context.get_user_input()
         data = get_data_parts(context.message.parts)[-1]
@@ -68,6 +67,7 @@ class PulseSynthExecutor(AgentExecutor):
             answer = final_state.get("answer", "No answer generated.")
             transcript = final_state.get(
                 "transcript", "No transcript generated.")
+            chapters = final_state.get("chapters", [])
 
             if final_state.get("is_answer_valid") and final_state.get("is_transcript_valid"):
                 # Use add_artifact for the long transcript and complete the task
@@ -76,6 +76,7 @@ class PulseSynthExecutor(AgentExecutor):
                         Part(root=DataPart(data={
                             "answer": answer,
                             "transcript": transcript,
+                            "chapters": chapters,
                         })),
 
                     ],
@@ -85,11 +86,11 @@ class PulseSynthExecutor(AgentExecutor):
                 await task_updater.update_status(TaskState.completed)
 
                 if callback_url:
-                    self.dependencies.logger.info(
+                    logger.info(
                         f"Firing callback to {callback_url} for thread {thread_id}")
                     # Use create_task to fire-and-forget, preventing the executor from hanging
                     asyncio.create_task(self._send_webhook(
-                        callback_url, thread_id,  answer, transcript))
+                        callback_url, thread_id, answer, transcript, chapters))
             else:
                 await task_updater.update_status(
                     TaskState.failed,
@@ -105,22 +106,23 @@ class PulseSynthExecutor(AgentExecutor):
                 new_agent_text_message(f"Synthesis failed: {str(e)}")
             )
 
-    async def _send_webhook(self, url: str, thread_id: str, answer: str, transcript: str):
+    async def _send_webhook(self, url: str, thread_id: str, answer: str, transcript: str, chapters: list):
         """Helper method to push the result back to the orchestrator."""
         payload = {
             "thread_id": thread_id,
             "answer": answer,
             "transcript": transcript,
+            "chapters": chapters,
             "status": "completed"
         }
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
                 response = await client.post(url, json=payload)
                 response.raise_for_status()
-                self.dependencies.logger.info(
+                logger.info(
                     f"Callback successfully delivered: HTTP {response.status_code}")
         except Exception as e:
-            self.dependencies.logger.error(
+            logger.error(
                 f"Failed to send callback to {url}: {e}")
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:

--- a/backend/agent_b_synth/graph.py
+++ b/backend/agent_b_synth/graph.py
@@ -8,6 +8,7 @@ from langgraph.types import Send
 from .nodes.node_generate_answer import node_generate_answer
 from .nodes.node_generate_transcript import node_generate_transcript
 from .nodes.node_supervisor_agent import node_reflection
+from .nodes.node_chapterize import node_chapterize
 
 from .state import SynthState
 
@@ -37,6 +38,7 @@ def build_synth_graph():
     workflow.add_node("generate_transcript", node_generate_transcript)
     workflow.add_node("generate_answer", node_generate_answer)
     workflow.add_node("reflection", node_reflection)
+    workflow.add_node("chapterize", node_chapterize)
 
     # Entry point relies on the dynamic router immediately
     # Assuming initial state has valid flags as False
@@ -52,6 +54,9 @@ def build_synth_graph():
         router,
         ["generate_answer", "generate_transcript", END]
     )
+
+    # After reflection succeeds, add chapterization
+    workflow.add_edge("reflection", "chapterize")
 
     # Compiling without a checkpointer here if state is strictly ephemeral per A2A task
     # (If you want to resume failed synthesis, you can attach postgres here as well)

--- a/backend/agent_b_synth/nodes/node_chapterize.py
+++ b/backend/agent_b_synth/nodes/node_chapterize.py
@@ -1,0 +1,58 @@
+import logging
+import json
+from langchain_core.messages import SystemMessage, HumanMessage
+from langgraph.runtime import Runtime
+from langgraph.config import RunnableConfig
+from ..state import SynthState, GraphContext, print_state
+from ..prompts.chapterize import CHAPTERIZER_PROMPT
+
+logger = logging.getLogger(__name__)
+
+
+async def node_chapterize(state: SynthState, runtime: Runtime[GraphContext], config: RunnableConfig) -> dict:
+    """
+    Splits the full meditation transcript into semantically coherent chapters.
+    Uses LLM to identify natural transition points while preserving instructional flow.
+    """
+    llm = runtime.context.llm
+    logger.info(f"CHAPTERIZING: {print_state(state)}")
+
+    full_transcript = state.get("transcript", "")
+
+    if not full_transcript or len(full_transcript.strip()) < 100:
+        logger.warning("Transcript too short for chapterization")
+        return {
+            "chapters": [full_transcript],
+        }
+
+    # Prepare the prompt with the full transcript
+    messages = [
+        SystemMessage(content=CHAPTERIZER_PROMPT),
+        HumanMessage(content=full_transcript)
+    ]
+
+    # Invoke LLM with JSON schema output
+    response = await llm.ainvoke(messages)
+
+    # Parse JSON output
+    try:
+        chapters_data = json.loads(response.content)
+        chapters = chapters_data.get("chapters", [])
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse chapterization response: {e}")
+        # Fallback: split by double newlines if JSON parsing fails
+        raw_chapters = full_transcript.split("\n\n")
+        chapters = [ch.strip() for ch in raw_chapters if ch.strip()]
+        logger.warning(
+            f"Fallback to naive split, got {len(chapters)} chapters")
+
+    # Ensure we have at least one chapter
+    if not chapters:
+        chapters = [full_transcript]
+
+    logger.info(f"Chapterized into {len(chapters)} chapters")
+
+    return {
+        "chapters": chapters,
+        "is_chapterized": True
+    }

--- a/backend/agent_b_synth/prompts/chapterize.py
+++ b/backend/agent_b_synth/prompts/chapterize.py
@@ -1,0 +1,36 @@
+import inspect
+
+CHAPTERIZER_PROMPT = inspect.cleandoc("""
+    You are a Semantic Chapterizer for meditation transcripts. Your task is to split a long meditation transcript into semantically coherent chapters.
+
+    # INPUT
+    You will receive a full meditation transcript.
+
+    # TASK
+    Analyze the transcript and identify natural thematic transitions (e.g., shifting from "Body Scan" to "Loving Kindness").
+    Split the transcript into chapters that:
+    1. Maintain complete instructional flow (never split in the middle of an inhale/exhale instruction).
+    2. Are semantically complete (each chapter should have a clear beginning and end).
+    3. Stay within 400-800 characters per chapter when possible.
+
+    # CONSTRAINTS
+    - NEVER split a breathing instruction (keep "inhale" and "exhale" together).
+    - NEVER split a complete thought or visualization sequence.
+    - Preserve all SSML tags (<break time="Xs"/>) exactly as they appear.
+    - Output ONLY a JSON array of strings. No markdown, no explanations.
+
+    # OUTPUT FORMAT
+    Return a JSON object with this exact structure:
+    {{
+        "chapters": ["chapter 1 text", "chapter 2 text", ...]
+    }}
+
+    # EXAMPLE
+    Input: "Welcome. Let us begin. Close your eyes. Feel your breath. Now shift to body scan..."
+    Output: {{
+        "chapters": [
+            "Welcome. Let us begin. Close your eyes. Feel your breath.",
+            "Now shift to body scan..."
+        ]
+    }}
+""")

--- a/backend/agent_b_synth/state.py
+++ b/backend/agent_b_synth/state.py
@@ -7,7 +7,6 @@ import json
 
 @dataclass
 class GraphContext:
-    logger: logging.Logger
     llm: BaseChatModel
 
 
@@ -17,6 +16,9 @@ class SynthState(TypedDict):
     answer: str
     is_transcript_valid: bool
     is_answer_valid: bool
+    chapters: list
+    chapter_count: int
+    is_chapterized: bool
 
 
 def print_state(state: SynthState) -> str:

--- a/client/src/api.gleam
+++ b/client/src/api.gleam
@@ -28,6 +28,7 @@ pub type AgentResponse {
     reply: String,
     answer: Option(String),
     transcript: Option(String),
+    chapters: Option(List(String)),
   )
 }
 
@@ -37,12 +38,17 @@ fn decode_agent_response() -> decode.Decoder(AgentResponse) {
   use reply <- decode.field("reply", decode.string)
   use answer <- decode.field("answer", decode.optional(decode.string))
   use transcript <- decode.field("transcript", decode.optional(decode.string))
+  use chapters <- decode.field(
+    "chapters",
+    decode.optional(decode.list(decode.string)),
+  )
   decode.success(AgentResponse(
     thread_id:,
     user_id:,
     reply:,
     answer:,
     transcript:,
+    chapters:,
   ))
 }
 

--- a/client/src/cartesia.gleam
+++ b/client/src/cartesia.gleam
@@ -22,6 +22,7 @@ pub type Model {
     ws: Option(ws.WebSocket),
     is_connected: Bool,
     input_text: String,
+    chapters: Option(List(String)),
     status_message: String,
     pending_chunks: List(String),
     current_context_index: Int,
@@ -273,7 +274,12 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
     }
 
     GenerateAudio -> {
-      let chunks = split_into_chapters(model.input_text)
+      let chunks =
+        case model.chapters {
+          Some(ch) -> ch
+          None -> split_into_chapters(model.input_text)
+        }
+        |> list.filter(fn(s) { string.length(s) > 0 })
 
       case chunks {
         [first, ..rest] -> {

--- a/client/src/client.gleam
+++ b/client/src/client.gleam
@@ -39,6 +39,7 @@ pub type Model {
     tts: cartesia.Model,
     answer: Option(String),
     transcript: Option(String),
+    chapters: Option(List(String)),
     access_token: Option(String),
     auth: auth.AuthState,
   )
@@ -75,6 +76,7 @@ fn init(_flags) -> #(Model, Effect(Msg)) {
       ws: None,
       is_connected: False,
       input_text: "",
+      chapters: None,
       status_message: "Disconnected",
       pending_chunks: [],
       current_context_index: 0,
@@ -92,6 +94,7 @@ fn init(_flags) -> #(Model, Effect(Msg)) {
       tts: tts,
       answer: None,
       transcript: None,
+      chapters: None,
       auth: auth,
       access_token: None,
     ),
@@ -126,7 +129,11 @@ fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
         Some(transcript) -> {
           let #(tts, eff) =
             cartesia.update(
-              cartesia.Model(..model.tts, input_text: transcript),
+              cartesia.Model(
+                ..model.tts,
+                input_text: transcript,
+                chapters: model.chapters,
+              ),
               cartesia.Connect,
             )
           #(Model(..model, tts: tts), effect.map(eff, CartesiaMsg))
@@ -151,6 +158,7 @@ fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
           thread_id: Some(msg.thread_id),
           answer: msg.answer,
           transcript: msg.transcript,
+          chapters: msg.chapters,
         ),
         // dom.scroll_to_bottom_delayed("chat-ancor"),
         case msg.transcript {


### PR DESCRIPTION
This pull request introduces **semantic chapterization** to the meditation synthesis workflow, enabling the system to automatically segment transcripts into meaningful chapters via an LLM.

---

### Core Logic & State Changes
* **New Nodes:** Integrated `node_chapterize` for the splitting logic and `node_deliver_transcript` to format the final output.
* **State Updates:** Modified `ChatState` and `SynthState` to include a dedicated `chapters` field.
* **Prompt Engineering:** Added a specialized `chapterize` prompt to guide the LLM in identifying semantic boundaries.

### API & Client Integration
* **Payload Updates:** Enhanced API responses to return chapter data alongside synthesis results.
* **Frontend Support:** Updated the client-side logic to handle chaptered data during **Cartesia** audio generation.

### Refactoring & Bug Fixes
* **Graph Cleanup:** Removed the redundant `node_deliver_transcript` from `graph.py` following its migration to a standalone node.
* **Stability:** Resolved a logger reference error within `agent_executor.py`.

---
> **Status:** 1 commit, 12 files changed. The branch is currently able to merge automatically.